### PR TITLE
fix: publish to npm with patch version

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,7 @@ on: [push]
 jobs:
   release:
     runs-on: ubuntu-latest
+    environment: deployment
     if: "!contains(github.event.head_commit.message, 'ci skip') && !contains(github.event.head_commit.message, 'skip ci')"
     steps:
       - uses: actions/checkout@v2
@@ -22,7 +23,7 @@ jobs:
 
       - name: Create Release
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: |
           yarn release

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ## What is it?
 
-This is a Storybook addon intended to let users see what is new with your repository. The recommendation is to link to your `CHANGELOG.md` for automated updates, or you can custom manage a Markdown file with more tailored updates.
+This is a Storybook addon intended to let users see what's new with your repository. The recommendation is to link to your `CHANGELOG.md` for automated updates, or you can custom manage a Markdown file with more tailored updates.
 
 ## How do I install it?
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,8 @@
 
 ## What is it?
 
-This is a Storybook addon intended to let users see what's new with your repository. The recommendation is to link to your `CHANGELOG.md` for automated updates, or you can custom manage a Markdown file with more tailored updates.
+This is a Storybook addon intended to let users see what's new with your repository.
+The recommendation is to link to your `CHANGELOG.md` for automated updates, or you can custom manage a Markdown file with more tailored updates.
 
 ## How do I install it?
 


### PR DESCRIPTION

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>1.0.1-canary.8.9a03fca.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install storybook-addon-whats-new@1.0.1-canary.8.9a03fca.0
  # or 
  yarn add storybook-addon-whats-new@1.0.1-canary.8.9a03fca.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
