### PR TITLE
fix: add npmrc

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+@kennethbigler:registry=https://npm.pkg.github.com


### PR DESCRIPTION

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>1.0.2-canary.9.7faaec9.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install storybook-addon-whats-new@1.0.2-canary.9.7faaec9.0
  # or 
  yarn add storybook-addon-whats-new@1.0.2-canary.9.7faaec9.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
