### PR TITLE
fix: remove preview reference and update docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ The recommendation is to link to your `CHANGELOG.md` for automated updates, or y
 Install the dependency:
 
 ``` sh
-yarn add -D @storybook-addon-whats-new
+yarn add -D storybook-addon-whats-new
 ```
 
 ### Storybook 5.3 and newer
@@ -30,7 +30,7 @@ Edit or create a file called `addons.js` in the Storybook config directory (by d
 Add following content to it:
 
 ``` js
-import 'storybook-addon-whats-new/register';
+import 'storybook-addon-whats-new';
 ```
 
 ## Getting Started

--- a/preset.js
+++ b/preset.js
@@ -1,12 +1,5 @@
-function config(entry = []) {
-  return [...entry, require.resolve("./dist/esm/preset/preview")];
-}
-
 function managerEntries(entry = []) {
   return [...entry, require.resolve("./dist/esm/preset/manager")];
 }
 
-module.exports = {
-  managerEntries,
-  config,
-};
+module.exports = { managerEntries };


### PR DESCRIPTION

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>1.0.3-canary.11.0892e50.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install storybook-addon-whats-new@1.0.3-canary.11.0892e50.0
  # or 
  yarn add storybook-addon-whats-new@1.0.3-canary.11.0892e50.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
